### PR TITLE
Update Facebook.php

### DIFF
--- a/src/apis/Facebook/Facebook.php
+++ b/src/apis/Facebook/Facebook.php
@@ -3,6 +3,12 @@ class Facebook extends Abstract_Api implements Api_Interface {
 	
 	public function __call( $name, $arguments ) {
 
+		if( strpos( $arguments[ 0 ], '/' ) !== 0 ){
+			
+			$arguments[ 0 ] = '/'.$arguments[ 0 ];
+		
+		}
+
 		return $this->_curl( 
 					strtolower( $name ), 
 					'https://graph.facebook.com/v2.3' . $arguments[ 0 ], 


### PR DESCRIPTION
Adds a sanity check to the URL endpoint. If the first character is not a slash, as is required by the API, it will prepend the endpoint with a slash.
