### PR TITLE
No longer support PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: php
 php:
   - 5.5
   - 5.4
-  - 5.3


### PR DESCRIPTION
Travis no longer supports PHP 5.3 out of the box. A lot of features of wrAPI are moving away from PHP 5 support, so let's deprecate 5.3